### PR TITLE
Fix link to Capability: Display map content in a users preferred language

### DIFF
--- a/mapml-ucrs-fulfillment-matrix.html
+++ b/mapml-ucrs-fulfillment-matrix.html
@@ -378,7 +378,7 @@
         <td>&nbsp;</td>
       </tr>
       <tr>
-        <th class="capability"><a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-preferred-language">Display map content in a users preferred language <span class="index">(5.1.6)</span></a></th>
+        <th class="capability"><a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#capability-preferred-language">Display map content in a users preferred language <span class="index">(5.1.6)</span></a></th>
         <td class="pass"><a href="#">pass</a></td>
         <td class="partial"><a href="#">partial</a></td>
         <td class="fail"><a href="#">fail</a></td>


### PR DESCRIPTION
Per the change in https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/pull/236/commits/410f8dfcb47695f9a8cb881285a3d3c6994667f2.