### PR TITLE
Small CSS tweaks

### DIFF
--- a/mapml-ucrs-fulfillment-matrix.html
+++ b/mapml-ucrs-fulfillment-matrix.html
@@ -9,12 +9,12 @@
     body {
       /* scroll-padding-top: 100px; */
       margin: 1rem;
+      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
     }
 
     dl {
       display: flex;
       flex-flow: row wrap;
-      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
     }
 
     dt {
@@ -35,7 +35,6 @@
       width: 100%;
       border-collapse: collapse;
       margin-bottom: 1rem;
-      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
     }
 
     thead > tr {

--- a/mapml-ucrs-fulfillment-matrix.html
+++ b/mapml-ucrs-fulfillment-matrix.html
@@ -46,6 +46,7 @@
         background-color: gray;
         position: sticky;
         top: 0; /* required for stickiness */
+        border: 0!important;
       }
 
     table td,


### PR DESCRIPTION
- https://github.com/Maps4HTML/UCR-MapML-Matrix/commit/8dc4b613625aeee189c24f1e27ea76751f10cbff applies the current font used for tables to the entire body (Times New Roman is pretty boring).
- https://github.com/Maps4HTML/UCR-MapML-Matrix/commit/291df5e7074187ab48cc0d9184909d614d3700b0 removes a 1px gap between sticky `<th>`s:<br><br><img width="300" src="https://user-images.githubusercontent.com/26493779/107545091-2b110180-6bcb-11eb-863e-0a3123500c93.png" alt>
