### PR TITLE
Pre-populate examples with `<title>` and links to Use Cases

### DIFF
--- a/examples/add-custom-control.html
+++ b/examples/add-custom-control.html
@@ -3,16 +3,16 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>***Description***</title>
-    <script type="module" src="../../dist/mapml-viewer.js"></script>
-    <link rel="stylesheet" href="../examples.css">
+    <title>Add Custom Control</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
   </head>
   <body>
     
     <h1>
       Example for
-      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-***ID***">
-        Use Case: ***Title***
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-add-custom-control">
+        Use Case: Add a custom control to a map
       </a>
     </h1>
       

--- a/examples/alternative-layers.html
+++ b/examples/alternative-layers.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Provide alternative map layers which the user can select</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-alternative-layers">
+        Use Case: Provide alternative map layers which the user can select
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/animate-view-change.html
+++ b/examples/animate-view-change.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Animate a map through a sequence of points</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-animate-view-change">
+        Use Case: Animate a map through a sequence of points
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/change-bearing-map.html
+++ b/examples/change-bearing-map.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Change the Bearing of a Map</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-change-bearing-map">
+        Use Case: Change the Bearing of a Map
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/create-map.html
+++ b/examples/create-map.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>Display an interactive map</title>
-    <script type="module" src="../../dist/mapml-viewer.js"></script>
-    <link rel="stylesheet" href="../examples.css">
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
   </head>
   <body>
     

--- a/examples/custom-map.html
+++ b/examples/custom-map.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Specify a data source for a map tile layer</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-custom-map">
+        Use Case: Display custom imagery as a map layer
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/generate-vector-features.html
+++ b/examples/generate-vector-features.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Show a vector data overlay</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-generate-vector-features">
+        Use Case: Generate new vector features from data
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/heatmap.html
+++ b/examples/heatmap.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Generate a heatmap overlay</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-heatmap">
+        Use Case: Generate a heatmap overlay from point intensity data
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/html-annotations.html
+++ b/examples/html-annotations.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Display custom HTML annotations</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-html-annotations">
+        Use Case: Display custom web content describing map features</a>
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/layers.html
+++ b/examples/layers.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Multi-layered maps</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-layers">
+        Author Use Case: Combine multiple layers of map tile data or features
+      </a>
+      and
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-hide-layers">
+        Web Visitor Use Case: Show/hide map layers or feature sets</a>
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/multiple-location-markers.html
+++ b/examples/multiple-location-markers.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Display multiple point locations as map markers</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-multiple-location-markers">
+        Use Case: Display multiple point locations as map markers
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/poly-features.html
+++ b/examples/poly-features.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Display routes/paths or regions</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-poly-features">
+        Use Case: Display routes/paths or regions
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/reset-map-view.html
+++ b/examples/reset-map-view.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Allow users to reset the map to their starting point</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-reset-map-view">
+        Use Case: Reset the map to the initial view
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/set-layer-visibility.html
+++ b/examples/set-layer-visibility.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Control which layers are currently visible & which can be hidden by the user</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-set-layer-visibility">
+        Use Case: Control which layers are currently visible & which can be hidden by the user
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/set-view-zoom.html
+++ b/examples/set-view-zoom.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Move a map to a new position and/or zoom level</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-set-view-zoom">
+        Use Case: Move a map to a new position and/or zoom level
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/show-and-hide-features-overlays.html
+++ b/examples/show-and-hide-features-overlays.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Show/hide map layers or feature sets</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-hide-layers">
+        Use Case: Show/hide map layers or feature sets
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/single-location.html
+++ b/examples/single-location.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Single Location Map Views</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-single-location">
+        Use Case: Display a location on a map
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/specify-data-source-map.html
+++ b/examples/specify-data-source-map.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>***Description***</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-***ID***">
+        Use Case: ***Title***
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/static-map.html
+++ b/examples/static-map.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Display a region of map data as a static image</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-static-map">
+        Display a region of map data as a static image
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/technical-drawings.html
+++ b/examples/technical-drawings.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Non-geographic content in map viewers</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-technical-drawings">
+        Use Case: Display drawings or schematics without geographic coordinates
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/template.html
+++ b/examples/template.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>***Description***</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-***ID***">
+        Use Case: ***Title***
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>

--- a/examples/use-case/create-map.html
+++ b/examples/use-case/create-map.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Display an interactive map (3.1.1)</title>
+    <title>Display an interactive map</title>
     <script type="module" src="../../dist/mapml-viewer.js"></script>
     <link rel="stylesheet" href="../examples.css">
   </head>

--- a/examples/view-change-events.html
+++ b/examples/view-change-events.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Provide feedback to a user as they manipulate the map</title>
+    <script type="module" src="../dist/mapml-viewer.js"></script>
+    <link rel="stylesheet" href="examples.css">
+  </head>
+  <body>
+    
+    <h1>
+      Example for
+      <a href="https://maps4html.org/HTML-Map-Element-UseCases-Requirements/#use-case-view-change-events">
+        Use Case: Provide feedback to a user as they manipulate the map
+      </a>
+    </h1>
+      
+    <!-- Map viewer
+    <mapml-viewer projection="" zoom="" lat="" lon="">
+      <layer- label="" src="" checked></layer->
+    </mapml-viewer>
+    -->
+    
+    <!-- HTML example
+    <code class="html-example">
+&lt;mapml-viewer projection="" zoom="" lat="" lon=""&gt;
+  &lt;layer- label="" src="" checked&gt;&lt;/layer-&gt;
+&lt;/mapml-viewer&gt;
+    </code>
+    -->
+    
+    <!-- Script example
+    <code class="script-example">
+      <script>
+// code
+      </script>
+    </code>
+    -->
+    
+  </body>
+</html>


### PR DESCRIPTION
This adds the same files that exist in https://github.com/Maps4HTML/HTML-Map-Element-UseCases-Requirements/tree/master/examples, but based on this repo's [template](https://github.com/Maps4HTML/UCR-MapML-Matrix/blob/main/examples/use-case/template.html).