### PR TITLE
Add Github mark with link to this repo

### DIFF
--- a/mapml-ucrs-fulfillment-matrix.html
+++ b/mapml-ucrs-fulfillment-matrix.html
@@ -134,7 +134,7 @@
     }
 
     .external_link::after,
-    a[href^="http"]::after {
+    a[href^="http"]:not(.github-mark)::after {
       content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' fill='cornflowerblue' width='14' height='14' viewBox='0 0 12 12'%3E%3Cpath d='M2,2 5,2 5,3 3,3 3,9 9,9 9,7 10,7 10,10 2,10M6.2,2 10,2 10,5.8 8.5,4.3 6.4,6.5 5.5,5.5 7.6,3.4'/%3E%3C/svg%3E");
       margin: 0 0 0 2px;
     }
@@ -203,6 +203,11 @@
       text-align: center;
       font-size: 0.75em;
     }
+    
+    .github-mark {
+      display: block;
+      width: max-content;
+    }
     </style>
 
   <script type="module" src="./main.js"></script>
@@ -210,6 +215,12 @@
 </head>
 
 <body>
+  <aside>
+    <a class="github-mark" href="https://github.com/Maps4HTML/UCR-MapML-Matrix" title="Github repository">
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="45" height="45" fill="none" viewBox="0 0 1024 1024"><defs/><path fill="#1B1F23" fill-rule="evenodd" d="M512 0A511.9 511.9 0 000 512c0 226.6 146.6 418 350 485.8 25.7 4.4 35.3-11 35.3-24.4 0-12.1-.7-52.4-.7-95.3-128.6 23.7-161.9-31.4-172.1-60.2-5.8-14.7-30.7-60.1-52.5-72.3-18-9.6-43.5-33.3-.6-34 40.3-.6 69 37.2 78.7 52.6 46 77.4 119.7 55.6 149.1 42.2 4.5-33.3 18-55.7 32.6-68.5-113.9-12.8-233-57-233-252.8 0-55.7 20-101.7 52.6-137.6-5.2-12.8-23-65.3 5-135.7 0 0 43-13.4 140.9 52.5a475 475 0 01128-17.3c43.5 0 87 5.8 128 17.3 97.9-66.5 140.8-52.5 140.8-52.5 28.1 70.4 10.2 123 5.1 135.7a198.1 198.1 0 0152.5 137.6c0 196.5-119.7 240-233.6 252.8 18.5 16 34.5 46.7 34.5 94.7 0 68.5-.6 123.6-.6 140.8 0 13.5 9.6 29.5 35.2 24.4A512.8 512.8 0 001024 512C1024 229.1 794.9 0 512 0z" clip-rule="evenodd"/></svg>
+    </a>
+  </aside>
+  
   <div class="container">
   <h1 id="title">MapML Use Case, Requirement, and Capability Matrix</h1>
   <p>This document compares the capabilities of existing popular web mapping libraries, comparing and contrasting implementations with the  <cite><a href="https://maps4html.org/MapML/spec/">MapML specification</a></cite> and the reference <a href="https://github.com/Maps4HTML/Web-Map-Custom-Element">MapML-Viewer custom-component polyfill</a>.</p>


### PR DESCRIPTION
Adds the GH mark, same as can be seen in https://maps4html.org/experiments/. I don't feel strongly about adding this, but some people may find it useful and I've found myself searching for the link in <q>The tables in this document are dynamically generated from a JSON file, [mapml-ucr.json](https://github.com/Maps4HTML/UCR-MapML-Matrix/blob/main/mapml-ucr.json)</q> just to get to this repo.