### PR TITLE
Add indicator for annotated `<td>` elements

### DIFF
--- a/mapml-ucrs-fulfillment-matrix.html
+++ b/mapml-ucrs-fulfillment-matrix.html
@@ -151,6 +151,16 @@
     .annotated {
       position: relative;
       cursor: help;
+      padding: 1rem;
+    }
+    
+    .annotated::after {
+      content: "🛈";
+      position: absolute;
+      top: 10px;
+      right: 5px;
+      line-height: 0;
+      font-size: 1rem;
     }
     
     td:not(.annotated) {


### PR DESCRIPTION
It's currently not possible to know which `<td>` elements are annotated before hovering them. This is a "quickfix" to indicate that, using an info symbol (🛈):

<img width="600" src="https://user-images.githubusercontent.com/26493779/126396347-18b4d175-beaf-428f-8a4b-593165dab7a8.png">
