### PR TITLE
Update icon for annotated `<td>` to use SVG

### DIFF
--- a/mapml-ucrs-fulfillment-matrix.html
+++ b/mapml-ucrs-fulfillment-matrix.html
@@ -155,12 +155,10 @@
     }
     
     .annotated::after {
-      content: "🛈";
+      content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16px' viewBox='0 0 24 24' width='16px' fill='%23000000'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M11 7h2v2h-2zm0 4h2v6h-2zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z'/%3E%3C/svg%3E");
       position: absolute;
-      top: 10px;
-      right: 5px;
-      line-height: 0;
-      font-size: 1rem;
+      top: 4px;
+      right: 4px;
     }
     
     td:not(.annotated) {


### PR DESCRIPTION
Use an SVG ([source](https://fonts.google.com/icons?selected=Material%20Icons%20Outlined%3Ainfo)) instead to fix this issue (seen in Chrome on Android):

<img width="300" src="https://user-images.githubusercontent.com/26493779/128208002-a8e8d9c8-664b-46df-a64c-bc2b86680e2c.jpg">